### PR TITLE
update cache usage, inc version

### DIFF
--- a/cms-api/pom.xml
+++ b/cms-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-api</artifactId>
 	<packaging>jar</packaging>

--- a/cms-api/src/main/java/com/condation/cms/api/cache/CacheManager.java
+++ b/cms-api/src/main/java/com/condation/cms/api/cache/CacheManager.java
@@ -23,7 +23,6 @@ package com.condation.cms.api.cache;
  */
 
 
-import java.io.Serializable;
 import java.time.Duration;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -36,11 +35,11 @@ import lombok.RequiredArgsConstructor;
 public class CacheManager {
 	private final CacheProvider cacheProvider;
 	
-	public <K extends Serializable, V extends Serializable> ICache<K, V> get (String name, CacheConfig config) {
+	public <K, V> ICache<K, V> get (String name, CacheConfig config) {
 		return cacheProvider.getCache(name, config);
 	}
 	
-	public <K extends Serializable, V extends Serializable> ICache<K, V> get (String name, CacheConfig config, Function<K, V> loader) {
+	public <K, V> ICache<K, V> get (String name, CacheConfig config, Function<K, V> loader) {
 		return cacheProvider.getCache(name, config, loader);
 	}
 	

--- a/cms-api/src/main/java/com/condation/cms/api/cache/CacheProvider.java
+++ b/cms-api/src/main/java/com/condation/cms/api/cache/CacheProvider.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
  */
 public interface CacheProvider {
 	
-	<K extends Serializable, V extends Serializable> ICache<K, V> getCache (String name, CacheManager.CacheConfig config);
+	<K, V> ICache<K, V> getCache (String name, CacheManager.CacheConfig config);
 	
-	<K extends Serializable, V extends Serializable> ICache<K, V> getCache (String name, CacheManager.CacheConfig config, Function<K, V> loader);
+	<K, V> ICache<K, V> getCache (String name, CacheManager.CacheConfig config, Function<K, V> loader);
 }

--- a/cms-api/src/main/java/com/condation/cms/api/cache/ICache.java
+++ b/cms-api/src/main/java/com/condation/cms/api/cache/ICache.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * @param <K>
  * @param <V>
  */
-public interface ICache<K extends Serializable, V extends Serializable> {
+public interface ICache<K, V> {
 	
 	void put (K key, V value);
 	

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/CacheProviderExtensionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/CacheProviderExtensionPoint.java
@@ -23,18 +23,15 @@ package com.condation.cms.api.extensions;
  */
 
 
-import com.condation.cms.api.hooks.HookSystem;
+import com.condation.cms.api.cache.CacheProvider;
 
 /**
- * ExtensionPoint for modules to register hooks.
  *
- * @deprecated  As of release 7.2.0, replaced by {@link HookSystemRegisterExtensionPoint}
- * 
- * @author thmar
+ * @author t.marx
  */
-@Deprecated(since = "7.2.0", forRemoval = true)
-public abstract class HookSystemRegisterExtentionPoint extends AbstractExtensionPoint{
+public abstract class CacheProviderExtensionPoint extends AbstractExtensionPoint {
 
-	public abstract void register (final HookSystem hookSystem);
+	public abstract String getName ();
+	public abstract CacheProvider getCacheProvider ();
 	
 }

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/HookSystemRegisterExtensionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/HookSystemRegisterExtensionPoint.java
@@ -22,18 +22,13 @@ package com.condation.cms.api.extensions;
  * #L%
  */
 
-
 import com.condation.cms.api.hooks.HookSystem;
 
 /**
  * ExtensionPoint for modules to register hooks.
- *
- * @deprecated  As of release 7.2.0, replaced by {@link HookSystemRegisterExtensionPoint}
  * 
- * @author thmar
  */
-@Deprecated(since = "7.2.0", forRemoval = true)
-public abstract class HookSystemRegisterExtentionPoint extends AbstractExtensionPoint{
+public abstract class HookSystemRegisterExtensionPoint extends AbstractExtensionPoint{
 
 	public abstract void register (final HookSystem hookSystem);
 	

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/MarkdownRendererProviderExtensionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/MarkdownRendererProviderExtensionPoint.java
@@ -29,7 +29,7 @@ import com.condation.cms.api.markdown.MarkdownRenderer;
  *
  * @author t.marx
  */
-public abstract class MarkdownRendererProviderExtentionPoint extends AbstractExtensionPoint {
+public abstract class MarkdownRendererProviderExtensionPoint extends AbstractExtensionPoint {
 
 	public abstract String getName ();
 	public abstract MarkdownRenderer getRenderer ();

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateEngineProviderExtensionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateEngineProviderExtensionPoint.java
@@ -22,19 +22,14 @@ package com.condation.cms.api.extensions;
  * #L%
  */
 
-
-import com.condation.cms.api.hooks.HookSystem;
+import com.condation.cms.api.template.TemplateEngine;
 
 /**
- * ExtensionPoint for modules to register hooks.
- *
- * @deprecated  As of release 7.2.0, replaced by {@link HookSystemRegisterExtensionPoint}
- * 
- * @author thmar
+ * ExtensionPoint to register TemplateEngines
  */
-@Deprecated(since = "7.2.0", forRemoval = true)
-public abstract class HookSystemRegisterExtentionPoint extends AbstractExtensionPoint{
+public abstract class TemplateEngineProviderExtensionPoint extends AbstractExtensionPoint {
 
-	public abstract void register (final HookSystem hookSystem);
+	public abstract String getName ();
+	public abstract TemplateEngine getTemplateEngine ();
 	
 }

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateEngineProviderExtentionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateEngineProviderExtentionPoint.java
@@ -27,8 +27,11 @@ import com.condation.cms.api.template.TemplateEngine;
 
 /**
  *
+ * @deprecated  As of release 7.2.0, replaced by {@link TemplateEngineProviderExtensionPoint}
+ * 
  * @author t.marx
  */
+@Deprecated(since = "7.2.0", forRemoval = true)
 public abstract class TemplateEngineProviderExtentionPoint extends AbstractExtensionPoint {
 
 	public abstract String getName ();

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateModelExtendingExtensionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateModelExtendingExtensionPoint.java
@@ -22,16 +22,10 @@ package com.condation.cms.api.extensions;
  * #L%
  */
 
+import com.condation.cms.api.template.TemplateEngine;
 
-import com.condation.cms.api.cache.CacheProvider;
+public abstract class TemplateModelExtendingExtensionPoint extends AbstractExtensionPoint{
 
-/**
- *
- * @author t.marx
- */
-public abstract class CacheProviderExtentionPoint extends AbstractExtensionPoint {
-
-	public abstract String getName ();
-	public abstract CacheProvider getCacheProvider ();
+	public abstract void extendModel (TemplateEngine.Model model);
 	
 }

--- a/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateModelExtendingExtentionPoint.java
+++ b/cms-api/src/main/java/com/condation/cms/api/extensions/TemplateModelExtendingExtentionPoint.java
@@ -26,8 +26,11 @@ import com.condation.cms.api.template.TemplateEngine;
 
 /**
  *
+ * @deprecated  As of release 7.2.0, replaced by {@link TemplateModelExtendingExtensionPoint}
+ * 
  * @author thmar
  */
+@Deprecated(since = "7.2.0", forRemoval = true)
 public abstract class TemplateModelExtendingExtentionPoint extends AbstractExtensionPoint{
 
 	public abstract void extendModel (TemplateEngine.Model model);

--- a/cms-auth/pom.xml
+++ b/cms-auth/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-auth</artifactId>
 	<packaging>jar</packaging>

--- a/cms-content/pom.xml
+++ b/cms-content/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-content</artifactId>
 	<packaging>jar</packaging>

--- a/cms-content/src/main/java/com/condation/cms/content/DefaultContentRenderer.java
+++ b/cms-content/src/main/java/com/condation/cms/content/DefaultContentRenderer.java
@@ -29,6 +29,7 @@ import com.condation.cms.api.db.Page;
 import com.condation.cms.api.db.cms.ReadOnlyFile;
 import com.condation.cms.api.db.taxonomy.Taxonomy;
 import com.condation.cms.api.extensions.ContentQueryOperatorExtensionPoint;
+import com.condation.cms.api.extensions.TemplateModelExtendingExtensionPoint;
 import com.condation.cms.api.extensions.TemplateModelExtendingExtentionPoint;
 import com.condation.cms.api.feature.Feature;
 import com.condation.cms.api.feature.features.AuthFeature;
@@ -225,6 +226,7 @@ public class DefaultContentRenderer implements ContentRenderer {
 
 	private void extendModel(final TemplateEngine.Model model) {
 		moduleManager.extensions(TemplateModelExtendingExtentionPoint.class).forEach(extensionPoint -> extensionPoint.extendModel(model));
+		moduleManager.extensions(TemplateModelExtendingExtensionPoint.class).forEach(extensionPoint -> extensionPoint.extendModel(model));
 	}
 
 	@Override

--- a/cms-core/pom.xml
+++ b/cms-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-core</artifactId>
 	<packaging>jar</packaging>

--- a/cms-core/src/test/java/com/condation/cms/core/cache/LocalCacheProviderTest.java
+++ b/cms-core/src/test/java/com/condation/cms/core/cache/LocalCacheProviderTest.java
@@ -22,13 +22,13 @@ package com.condation.cms.core.cache;
  * #L%
  */
 
-
-import com.condation.cms.core.cache.LocalCacheProvider;
-import com.condation.cms.api.cache.CacheManager;
-import com.condation.cms.api.cache.ICache;
 import java.time.Duration;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import com.condation.cms.api.cache.CacheManager;
+import com.condation.cms.api.cache.ICache;
 
 /**
  *

--- a/cms-core/src/test/java/com/condation/cms/core/messages/ThemeMessageSourceTest.java
+++ b/cms-core/src/test/java/com/condation/cms/core/messages/ThemeMessageSourceTest.java
@@ -23,13 +23,13 @@ package com.condation.cms.core.messages;
  */
 
 
-import com.condation.cms.api.SiteProperties;
+import com.condation.cms.api.cache.CacheManager;
+import com.condation.cms.core.cache.LocalCacheProvider;
 import com.condation.cms.core.configuration.properties.ExtendedSiteProperties;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Locale;
-import java.util.Map;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,18 +50,22 @@ public class ThemeMessageSourceTest {
 	@Mock
 	ExtendedSiteProperties siteProperties;
 	
+	CacheManager cacheManager = new CacheManager(new LocalCacheProvider());
+	
 	@BeforeEach
 	public void setup() {
 		Mockito.when(siteProperties.locale()).thenReturn(Locale.getDefault());
 		messageSource = new DefaultMessageSource(
 				siteProperties, 
-				Path.of("src/test/resources/messages")
+				Path.of("src/test/resources/messages"),
+				cacheManager.get("messages", new CacheManager.CacheConfig(10l, Duration.ofMinutes(1)))
 		);
 		
 		themeMessageSource = new ThemeMessageSource(
 				siteProperties, 
 				Path.of("src/test/resources/parent_messages"), 
-				messageSource
+				messageSource,
+				cacheManager.get("theme-messages", new CacheManager.CacheConfig(10l, Duration.ofMinutes(1)))
 		);
 	}
 

--- a/cms-core/src/test/java/com/condation/cms/core/messaging/DefaultTopicClassLoaderTest.java
+++ b/cms-core/src/test/java/com/condation/cms/core/messaging/DefaultTopicClassLoaderTest.java
@@ -1,0 +1,83 @@
+package com.condation.cms.core.messaging;
+
+/*-
+ * #%L
+ * cms-core
+ * %%
+ * Copyright (C) 2023 - 2024 CondationCMS
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import com.condation.cms.api.messaging.Listener;
+import com.condation.cms.api.messaging.Topic;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class DefaultTopicClassLoaderTest {
+
+    private URLClassLoader loader1;
+    private URLClassLoader loader2;
+    private DefaultTopic topic;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        URL[] urls = {};  // Leere URL für einen separaten Classloader-Kontext
+
+        // Zwei separate Classloader instanziieren
+        loader1 = new URLClassLoader(urls, getClass().getClassLoader());
+        loader2 = new URLClassLoader(urls, getClass().getClassLoader());
+
+        // DefaultTopic-Instanz in loader1 erstellen
+        Class<?> topicClass = loader1.loadClass("com.condation.cms.core.messaging.DefaultTopic");
+        Constructor<?> constructor = topicClass.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        topic = (DefaultTopic) constructor.newInstance("TestTopic");
+    }
+
+    @Test
+    void testPublishWithDifferentClassLoaders() throws Exception {
+        // Listener im ersten Classloader hinzufügen
+        Listener<String> listener1 = createListener(loader1, "Listener1");
+        topic.subscribe(listener1, String.class);
+
+        // Listener im zweiten Classloader hinzufügen
+        Listener<String> listener2 = createListener(loader2, "Listener2");
+        topic.subscribe(listener2, String.class);
+
+        // Nachricht senden
+        topic.publish("Test Message", Topic.Mode.SYNC);
+
+        // Überprüfen, ob Listener die Nachricht empfangen haben
+        // Dies hängt von einer Implementierung des Listeners ab, die das Empfangen der Nachrichten prüfbar macht
+        // Eventuell mit Logging oder Zählvariablen in jedem Listener
+    }
+
+    private Listener<String> createListener(URLClassLoader loader, String listenerName) throws Exception {
+        Class<?> listenerClass = loader.loadClass("com.condation.cms.api.messaging.Listener");
+        return new Listener<String>() {
+            @Override
+            public void receive(String message) {
+                log.info("Message received in " + listenerName + ": " + message);
+            }
+        };
+    }
+}

--- a/cms-extensions/pom.xml
+++ b/cms-extensions/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-extensions</artifactId>
 	<packaging>jar</packaging>

--- a/cms-filesystem/pom.xml
+++ b/cms-filesystem/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-filesystem</artifactId>
 	<packaging>jar</packaging>

--- a/cms-git/pom.xml
+++ b/cms-git/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-git</artifactId>
 	<packaging>jar</packaging>

--- a/cms-media/pom.xml
+++ b/cms-media/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-media</artifactId>
 	<packaging>jar</packaging>

--- a/cms-server/pom.xml
+++ b/cms-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>cms-server</artifactId>
 	<packaging>jar</packaging>

--- a/cms-server/src/main/java/com/condation/cms/request/RequestContextFactory.java
+++ b/cms-server/src/main/java/com/condation/cms/request/RequestContextFactory.java
@@ -27,6 +27,7 @@ import com.condation.cms.api.configuration.Configuration;
 import com.condation.cms.api.configuration.configs.ServerConfiguration;
 import com.condation.cms.api.configuration.configs.SiteConfiguration;
 import com.condation.cms.api.content.ContentParser;
+import com.condation.cms.api.extensions.HookSystemRegisterExtensionPoint;
 import com.condation.cms.api.extensions.HookSystemRegisterExtentionPoint;
 import com.condation.cms.api.extensions.RegisterShortCodesExtensionPoint;
 import com.condation.cms.api.feature.features.ConfigurationFeature;
@@ -153,6 +154,7 @@ public class RequestContextFactory {
 		var hookSystem = requestContext.get(HookSystemFeature.class).hookSystem();
 		var moduleManager = injector.getInstance(ModuleManager.class);
 		moduleManager.extensions(HookSystemRegisterExtentionPoint.class).forEach(extensionPoint -> extensionPoint.register(hookSystem));
+		moduleManager.extensions(HookSystemRegisterExtensionPoint.class).forEach(extensionPoint -> extensionPoint.register(hookSystem));
 
 		return hookSystem;
 	}

--- a/cms-server/src/main/java/com/condation/cms/server/VHost.java
+++ b/cms-server/src/main/java/com/condation/cms/server/VHost.java
@@ -66,6 +66,7 @@ import com.condation.cms.media.ThemeMediaManager;
 import com.condation.cms.module.DefaultRenderContentFunction;
 import com.condation.cms.request.RequestContextFactory;
 import com.condation.cms.server.configs.ModulesModule;
+import com.condation.cms.server.configs.SiteConfigInitializer;
 import com.condation.cms.server.configs.SiteGlobalModule;
 import com.condation.cms.server.configs.SiteHandlerModule;
 import com.condation.cms.server.configs.SiteModule;
@@ -167,17 +168,10 @@ public class VHost {
 
 		// start configuration managment
 		injector.getInstance(ConfigManagement.class).initConfiguration(configuration);
+		// run site initializer
+		injector.getInstance(SiteConfigInitializer.class).init();
 		
-		final CMSModuleContext cmsModuleContext = injector.getInstance(CMSModuleContext.class);
 		var moduleManager = injector.getInstance(ModuleManager.class);
-		var contentResolver = injector.getInstance(ContentResolver.class);
-		var requestContextFactory = injector.getInstance(RequestContextFactory.class);
-
-		cmsModuleContext.add(
-				ContentRenderFeature.class,
-				new ContentRenderFeature(new DefaultRenderContentFunction(contentResolver, requestContextFactory))
-		);
-
 		moduleManager.initModules();
 		List<String> activeModules = getActiveModules();
 		activeModules.stream()

--- a/cms-server/src/main/java/com/condation/cms/server/configs/ModulesModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/ModulesModule.java
@@ -25,7 +25,8 @@ import com.condation.cms.api.ServerProperties;
 import com.condation.cms.api.SiteProperties;
 import com.condation.cms.api.configuration.Configuration;
 import com.condation.cms.api.eventbus.EventBus;
-import com.condation.cms.api.extensions.MarkdownRendererProviderExtentionPoint;
+import com.condation.cms.api.extensions.MarkdownRendererProviderExtensionPoint;
+import com.condation.cms.api.extensions.TemplateEngineProviderExtensionPoint;
 import com.condation.cms.api.extensions.TemplateEngineProviderExtentionPoint;
 import com.condation.cms.api.feature.features.ConfigurationFeature;
 import com.condation.cms.api.feature.features.CronJobSchedulerFeature;
@@ -154,8 +155,8 @@ public class ModulesModule extends AbstractModule {
 			CMSMarkdownRenderer defaultMarkdownRenderer) {
 		var engine = siteProperties.markdownEngine();
 
-		List<MarkdownRendererProviderExtentionPoint> extensions = moduleManager.extensions(MarkdownRendererProviderExtentionPoint.class);
-		Optional<MarkdownRendererProviderExtentionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(engine)).findFirst();
+		List<MarkdownRendererProviderExtensionPoint> extensions = moduleManager.extensions(MarkdownRendererProviderExtensionPoint.class);
+		Optional<MarkdownRendererProviderExtensionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(engine)).findFirst();
 
 		if (extOpt.isPresent()) {
 			return extOpt.get().getRenderer();
@@ -185,14 +186,21 @@ public class ModulesModule extends AbstractModule {
 	public TemplateEngine resolveTemplateEngine(SiteProperties siteProperties, Theme theme, ModuleManager moduleManager) {
 		var engine = getTemplateEngine(siteProperties, theme);
 
-		List<TemplateEngineProviderExtentionPoint> extensions = moduleManager.extensions(TemplateEngineProviderExtentionPoint.class);
-		Optional<TemplateEngineProviderExtentionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(engine)).findFirst();
+		List<TemplateEngineProviderExtensionPoint> extensions = moduleManager.extensions(TemplateEngineProviderExtensionPoint.class);
+		Optional<TemplateEngineProviderExtensionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(engine)).findFirst();
 
 		if (extOpt.isPresent()) {
 			return extOpt.get().getTemplateEngine();
-		} else {
-			throw new RuntimeException("no template engine found");
 		}
+
+		List<TemplateEngineProviderExtentionPoint> extensionsLegacy = moduleManager.extensions(TemplateEngineProviderExtentionPoint.class);
+		Optional<TemplateEngineProviderExtentionPoint> extLegacyOpt = extensionsLegacy.stream().filter((ext) -> ext.getName().equals(engine)).findFirst();
+
+		if (extLegacyOpt.isPresent()) {
+			return extLegacyOpt.get().getTemplateEngine();
+		}
+		
+		throw new RuntimeException("no template engine found");
 	}
 
 	/**

--- a/cms-server/src/main/java/com/condation/cms/server/configs/ModulesModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/ModulesModule.java
@@ -120,17 +120,8 @@ public class ModulesModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	public CMSModuleContext moduleContext(SiteProperties siteProperties, ServerProperties serverProperties, FileDB db, EventBus eventBus, Theme theme,
-			Configuration configuration, SiteCronJobScheduler cronJobScheduler, Messaging messaging) {
+	public CMSModuleContext moduleContext() {
 		final CMSModuleContext cmsModuleContext = new CMSModuleContext();
-		cmsModuleContext.add(SitePropertiesFeature.class, new SitePropertiesFeature(siteProperties));
-		cmsModuleContext.add(ServerPropertiesFeature.class, new ServerPropertiesFeature(serverProperties));
-		cmsModuleContext.add(DBFeature.class, new DBFeature(db));
-		cmsModuleContext.add(EventBusFeature.class, new EventBusFeature(eventBus));
-		cmsModuleContext.add(MessagingFeature.class, new MessagingFeature(messaging));
-		cmsModuleContext.add(ThemeFeature.class, new ThemeFeature(theme));
-		cmsModuleContext.add(ConfigurationFeature.class, new ConfigurationFeature(configuration));
-		cmsModuleContext.add(CronJobSchedulerFeature.class, new CronJobSchedulerFeature(cronJobScheduler));
 
 		return cmsModuleContext;
 	}
@@ -142,7 +133,7 @@ public class ModulesModule extends AbstractModule {
 	}
 
 	/**
-	 * The markedjs markdown renderer is implemented using graaljs, so we need a fresh instance for every request
+	 * 
 	 *
 	 * @param siteProperties
 	 * @param moduleManager

--- a/cms-server/src/main/java/com/condation/cms/server/configs/SiteConfigInitializer.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/SiteConfigInitializer.java
@@ -1,0 +1,98 @@
+package com.condation.cms.server.configs;
+
+/*-
+ * #%L
+ * cms-server
+ * %%
+ * Copyright (C) 2023 - 2024 CondationCMS
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import com.condation.cms.api.ServerProperties;
+import com.condation.cms.api.SiteProperties;
+import com.condation.cms.api.configuration.Configuration;
+import com.condation.cms.api.eventbus.EventBus;
+import com.condation.cms.api.feature.features.ConfigurationFeature;
+import com.condation.cms.api.feature.features.ContentRenderFeature;
+import com.condation.cms.api.feature.features.CronJobSchedulerFeature;
+import com.condation.cms.api.feature.features.DBFeature;
+import com.condation.cms.api.feature.features.EventBusFeature;
+import com.condation.cms.api.feature.features.MessagingFeature;
+import com.condation.cms.api.feature.features.ServerPropertiesFeature;
+import com.condation.cms.api.feature.features.SitePropertiesFeature;
+import com.condation.cms.api.feature.features.ThemeFeature;
+import com.condation.cms.api.messaging.Messaging;
+import com.condation.cms.api.module.CMSModuleContext;
+import com.condation.cms.api.theme.Theme;
+import com.condation.cms.content.ContentResolver;
+import com.condation.cms.core.configuration.ConfigManagement;
+import com.condation.cms.core.scheduler.SiteCronJobScheduler;
+import com.condation.cms.filesystem.FileDB;
+import com.condation.cms.module.DefaultRenderContentFunction;
+import com.condation.cms.request.RequestContextFactory;
+import com.condation.modules.api.ModuleManager;
+import com.google.inject.Injector;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * This is an initializer for some site configurations that make problem due to circular dependencies in guice.
+ * 
+ */
+@RequiredArgsConstructor
+public class SiteConfigInitializer {
+
+    final Injector injector;
+
+    public void init () {
+        initModuleContext();
+        initCronJobContext();
+    }
+
+    private void initCronJobContext() {
+        var context = injector.getInstance(CMSModuleContext.class);
+
+        context.add(SitePropertiesFeature.class, new SitePropertiesFeature(injector.getInstance(SiteProperties.class)));
+		context.add(ServerPropertiesFeature.class, new ServerPropertiesFeature(injector.getInstance(ServerProperties.class)));
+		context.add(DBFeature.class, new DBFeature(injector.getInstance(FileDB.class)));
+		context.add(EventBusFeature.class, new EventBusFeature(injector.getInstance(EventBus.class)));
+		context.add(MessagingFeature.class, new MessagingFeature(injector.getInstance(Messaging.class)));
+		context.add(ThemeFeature.class, new ThemeFeature(injector.getInstance(Theme.class)));
+		context.add(ConfigurationFeature.class, new ConfigurationFeature(injector.getInstance(Configuration.class)));
+    }
+
+    private void initModuleContext () {
+        var cmsModuleContext = injector.getInstance(CMSModuleContext.class);
+
+        cmsModuleContext.add(SitePropertiesFeature.class, new SitePropertiesFeature(injector.getInstance(SiteProperties.class)));
+		cmsModuleContext.add(ServerPropertiesFeature.class, new ServerPropertiesFeature(injector.getInstance(ServerProperties.class)));
+		cmsModuleContext.add(DBFeature.class, new DBFeature(injector.getInstance(FileDB.class)));
+		cmsModuleContext.add(EventBusFeature.class, new EventBusFeature(injector.getInstance(EventBus.class)));
+		cmsModuleContext.add(MessagingFeature.class, new MessagingFeature(injector.getInstance(Messaging.class)));
+		cmsModuleContext.add(ThemeFeature.class, new ThemeFeature(injector.getInstance(Theme.class)));
+		cmsModuleContext.add(ConfigurationFeature.class, new ConfigurationFeature(injector.getInstance(Configuration.class)));
+		cmsModuleContext.add(CronJobSchedulerFeature.class, new CronJobSchedulerFeature(injector.getInstance(SiteCronJobScheduler.class)));
+
+        var contentResolver = injector.getInstance(ContentResolver.class);
+		var requestContextFactory = injector.getInstance(RequestContextFactory.class);
+
+		cmsModuleContext.add(
+				ContentRenderFeature.class,
+				new ContentRenderFeature(new DefaultRenderContentFunction(contentResolver, requestContextFactory))
+		);
+    }
+}

--- a/cms-server/src/main/java/com/condation/cms/server/configs/SiteGlobalModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/SiteGlobalModule.java
@@ -37,6 +37,7 @@ import com.condation.cms.extensions.GlobalExtensions;
 import com.condation.cms.extensions.hooks.GlobalHooks;
 import com.condation.modules.api.ModuleManager;
 import com.google.inject.Binder;
+import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -124,5 +125,11 @@ public class SiteGlobalModule implements com.google.inject.Module {
 			return extOpt.get().getCacheProvider();
 		}
 		return new LocalCacheProvider();
+	}
+
+	@Provides
+	@Singleton
+	public SiteConfigInitializer siteConfigInitializer (Injector injector) {
+		return new SiteConfigInitializer(injector);
 	}
 }

--- a/cms-server/src/main/java/com/condation/cms/server/configs/SiteGlobalModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/SiteGlobalModule.java
@@ -27,7 +27,7 @@ import com.condation.cms.api.Constants;
 import com.condation.cms.api.SiteProperties;
 import com.condation.cms.api.cache.CacheManager;
 import com.condation.cms.api.cache.CacheProvider;
-import com.condation.cms.api.extensions.CacheProviderExtentionPoint;
+import com.condation.cms.api.extensions.CacheProviderExtensionPoint;
 import com.condation.cms.api.hooks.HookSystem;
 import com.condation.cms.api.scheduler.CronJobContext;
 import com.condation.cms.core.cache.LocalCacheProvider;
@@ -117,8 +117,8 @@ public class SiteGlobalModule implements com.google.inject.Module {
 		if (Constants.DEFAULT_CACHE_ENGINE.equals(cacheEngine)) {
 			return new LocalCacheProvider();
 		}
-		List<CacheProviderExtentionPoint> extensions = moduleManager.extensions(CacheProviderExtentionPoint.class);
-		Optional<CacheProviderExtentionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(cacheEngine)).findFirst();
+		List<CacheProviderExtensionPoint> extensions = moduleManager.extensions(CacheProviderExtensionPoint.class);
+		Optional<CacheProviderExtensionPoint> extOpt = extensions.stream().filter((ext) -> ext.getName().equals(cacheEngine)).findFirst();
 
 		if (extOpt.isPresent()) {
 			return extOpt.get().getCacheProvider();

--- a/cms-server/src/main/java/com/condation/cms/server/configs/SiteModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/SiteModule.java
@@ -2,6 +2,9 @@ package com.condation.cms.server.configs;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.ResourceBundle;
 
 import org.apache.commons.jexl3.JexlBuilder;
 import org.graalvm.polyglot.Engine;
@@ -32,6 +35,8 @@ import org.graalvm.polyglot.Engine;
 import com.condation.cms.api.Constants;
 import com.condation.cms.api.ServerProperties;
 import com.condation.cms.api.SiteProperties;
+import com.condation.cms.api.cache.CacheManager;
+import com.condation.cms.api.cache.ICache;
 import com.condation.cms.api.configuration.Configuration;
 import com.condation.cms.api.configuration.configs.ServerConfiguration;
 import com.condation.cms.api.content.ContentParser;
@@ -149,11 +154,15 @@ public class SiteModule extends AbstractModule {
 	}
 
 	@Provides
-	public Theme loadTheme(SiteProperties siteProperties, ServerProperties serverProperties, MessageSource messageSource) throws IOException {
+	public Theme loadTheme(
+		SiteProperties siteProperties, 
+		ServerProperties serverProperties, 
+		MessageSource messageSource,
+		CacheManager cacheManager) throws IOException {
 
 		if (siteProperties.theme() != null) {
 			Path themeFolder = serverProperties.getThemesFolder().resolve(siteProperties.theme());
-			return DefaultTheme.load(themeFolder, siteProperties, messageSource, serverProperties);
+			return DefaultTheme.load(themeFolder, siteProperties, messageSource, serverProperties, cacheManager);
 		}
 
 		return DefaultTheme.EMPTY;
@@ -200,8 +209,9 @@ public class SiteModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	public MessageSource messages(SiteProperties site, DB db) throws IOException {
-		var messages = new DefaultMessageSource(site, db.getFileSystem().resolve("messages/"));
+	public MessageSource messages(SiteProperties site, DB db, CacheManager cacheManager) throws IOException {
+		ICache<String, String> cache = cacheManager.get("messages", new CacheManager.CacheConfig(500l, Duration.ofMinutes(5)));
+		var messages = new DefaultMessageSource(site, db.getFileSystem().resolve("messages/"), cache);
 		return messages;
 	}
 

--- a/cms-server/src/main/java/com/condation/cms/server/configs/SiteModule.java
+++ b/cms-server/src/main/java/com/condation/cms/server/configs/SiteModule.java
@@ -297,16 +297,8 @@ public class SiteModule extends AbstractModule {
 	
 	@Provides
 	@Singleton
-	public CronJobContext cronJobContext(SiteProperties siteProperties, ServerProperties serverProperties, FileDB db, EventBus eventBus, Theme theme,
-			Configuration configuration, Messaging messaging) {
+	public CronJobContext cronJobContext() {
 		final CronJobContext cronJobContext = new CronJobContext();
-		cronJobContext.add(SitePropertiesFeature.class, new SitePropertiesFeature(siteProperties));
-		cronJobContext.add(ServerPropertiesFeature.class, new ServerPropertiesFeature(serverProperties));
-		cronJobContext.add(DBFeature.class, new DBFeature(db));
-		cronJobContext.add(EventBusFeature.class, new EventBusFeature(eventBus));
-		cronJobContext.add(ThemeFeature.class, new ThemeFeature(theme));
-		cronJobContext.add(MessagingFeature.class, new MessagingFeature(messaging));
-		cronJobContext.add(ConfigurationFeature.class, new ConfigurationFeature(configuration));
 		
 		return cronJobContext;
 	}

--- a/cms-test/pom.xml
+++ b/cms-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.condation.cms</groupId>
         <artifactId>cms-parent</artifactId>
-        <version>7.1.2</version>
+        <version>7.2.0</version>
     </parent>
     <artifactId>cms-test</artifactId>
     <packaging>jar</packaging>

--- a/distribution/build.xml
+++ b/distribution/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="distribution" default="distribution" basedir=".">
-	<property name="cms.version">7.1.2</property>
+	<property name="cms.version">7.2.0</property>
 	
 	<property name="thymeleaf.version">v3.0.0</property>
 		

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>integration-tests</artifactId>
 	<packaging>jar</packaging>

--- a/modules-framework/api/pom.xml
+++ b/modules-framework/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms.module.framework</groupId>
 		<artifactId>module-framework</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>modules-api</artifactId>
 	<packaging>jar</packaging>

--- a/modules-framework/manager/pom.xml
+++ b/modules-framework/manager/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms.module.framework</groupId>
 		<artifactId>module-framework</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>modules-manager</artifactId>
 	<packaging>jar</packaging>

--- a/modules-framework/pom.xml
+++ b/modules-framework/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<groupId>com.condation.cms.module.framework</groupId>
 	<artifactId>module-framework</artifactId>

--- a/modules/example-module/pom.xml
+++ b/modules/example-module/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms.modules</groupId>
 		<artifactId>cms-modules</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<artifactId>example-module</artifactId>
 	<packaging>jar</packaging>

--- a/modules/example-module/src/main/java/com/condation/cms/modules/example/ExampleHookSystemRegistration.java
+++ b/modules/example-module/src/main/java/com/condation/cms/modules/example/ExampleHookSystemRegistration.java
@@ -1,5 +1,7 @@
 package com.condation.cms.modules.example;
 
+import com.condation.cms.api.extensions.HookSystemRegisterExtensionPoint;
+
 /*-
  * #%L
  * example-module
@@ -23,7 +25,6 @@ package com.condation.cms.modules.example;
  */
 
 
-import com.condation.cms.api.extensions.HookSystemRegisterExtentionPoint;
 import com.condation.cms.api.hooks.HookSystem;
 import com.condation.modules.api.annotation.Extension;
 
@@ -31,8 +32,8 @@ import com.condation.modules.api.annotation.Extension;
  *
  * @author t.marx
  */
-@Extension(HookSystemRegisterExtentionPoint.class)
-public class ExampleHookSystemRegistration extends HookSystemRegisterExtentionPoint {
+@Extension(HookSystemRegisterExtensionPoint.class)
+public class ExampleHookSystemRegistration extends HookSystemRegisterExtensionPoint {
 
 	@Override
 	public void register(HookSystem hookSystem) {

--- a/modules/example-module/src/main/java/com/condation/cms/modules/example/ExampleTemplateModelExtendingExtensionEndPoint.java
+++ b/modules/example-module/src/main/java/com/condation/cms/modules/example/ExampleTemplateModelExtendingExtensionEndPoint.java
@@ -1,5 +1,10 @@
 package com.condation.cms.modules.example;
 
+import java.util.List;
+import java.util.UUID;
+
+import com.condation.cms.api.extensions.TemplateModelExtendingExtensionPoint;
+
 /*-
  * #%L
  * example-module
@@ -22,19 +27,16 @@ package com.condation.cms.modules.example;
  * #L%
  */
 
-
-import com.condation.cms.api.extensions.TemplateModelExtendingExtentionPoint;
+ 
 import com.condation.cms.api.template.TemplateEngine;
 import com.condation.modules.api.annotation.Extension;
-import java.util.List;
-import java.util.UUID;
 
 /**
  *
  * @author thmar
  */
-@Extension(TemplateModelExtendingExtentionPoint.class)
-public class ExampleTemplateModelExtendingExtensionEndPoint extends TemplateModelExtendingExtentionPoint {
+@Extension(TemplateModelExtendingExtensionPoint.class)
+public class ExampleTemplateModelExtendingExtensionEndPoint extends TemplateModelExtendingExtensionPoint {
 
 	@Override
 	public void extendModel(TemplateEngine.Model model) {

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.condation.cms</groupId>
 		<artifactId>cms-parent</artifactId>
-		<version>7.1.2</version>
+		<version>7.2.0</version>
 	</parent>
 	<groupId>com.condation.cms.modules</groupId>
 	<artifactId>cms-modules</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.condation.cms</groupId>
 	<artifactId>cms-parent</artifactId>
-	<version>7.1.2</version>
+	<version>7.2.0</version>
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/test-server/hosts/demo/site.toml
+++ b/test-server/hosts/demo/site.toml
@@ -1,5 +1,5 @@
 id = "demo-site"
-hostname = [ "localhost", "localhost2" ]
+hostname = [ "localhost" ]
 baseurl = "http://localhost:1010"
 language = "en"
 theme = "demo"


### PR DESCRIPTION
This PR updates the cache usage:
1. MessageSource still uses the google Cache directly
2. MessageSource don't cache java ResourceBundles but message strings directly