### PR TITLE
MapAccess to better access sub maps in template code

### DIFF
--- a/cms-content/pom.xml
+++ b/cms-content/pom.xml
@@ -23,6 +23,10 @@
 			<artifactId>cms-extensions</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.condation.cms</groupId>
+			<artifactId>cms-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>

--- a/cms-content/src/main/java/com/condation/cms/content/DefaultContentRenderer.java
+++ b/cms-content/src/main/java/com/condation/cms/content/DefaultContentRenderer.java
@@ -31,7 +31,6 @@ import com.condation.cms.api.db.taxonomy.Taxonomy;
 import com.condation.cms.api.extensions.ContentQueryOperatorExtensionPoint;
 import com.condation.cms.api.extensions.TemplateModelExtendingExtensionPoint;
 import com.condation.cms.api.extensions.TemplateModelExtendingExtentionPoint;
-import com.condation.cms.api.feature.Feature;
 import com.condation.cms.api.feature.features.AuthFeature;
 import com.condation.cms.api.feature.features.HookSystemFeature;
 import com.condation.cms.api.feature.features.InjectorFeature;
@@ -48,6 +47,7 @@ import com.condation.cms.api.utils.PathUtil;
 import com.condation.cms.api.utils.SectionUtil;
 import com.condation.cms.content.pipeline.ContentPipelineFactory;
 import com.condation.cms.content.views.model.View;
+import com.condation.cms.core.content.MapAccess;
 import com.condation.cms.extensions.hooks.DBHooks;
 import com.condation.cms.extensions.hooks.TemplateHooks;
 import com.condation.cms.content.template.functions.LinkFunction;
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -140,7 +139,7 @@ public class DefaultContentRenderer implements ContentRenderer {
 
 		modelExtending.accept(model);
 
-		model.values.put("meta", meta);
+		model.values.put("meta", new MapAccess(meta));
 		model.values.put("sections", sections);
 
 		model.values.put("shortCodes", createShortCodeFunction(context));

--- a/cms-core/src/main/java/com/condation/cms/core/content/MapAccess.java
+++ b/cms-core/src/main/java/com/condation/cms/core/content/MapAccess.java
@@ -1,0 +1,98 @@
+package com.condation.cms.core.content;
+
+/*-
+ * #%L
+ * cms-core
+ * %%
+ * Copyright (C) 2023 - 2024 CondationCMS
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.condation.cms.api.utils.MapUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MapAccess implements Map<String, Object> {
+
+    private final Map<String, Object> wrapped;
+
+    @Override
+    public int size() {
+        return wrapped.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return wrapped.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return MapUtil.getValue(wrapped, (String)key) != null;    
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new UnsupportedOperationException("Unimplemented method 'containsValue'");
+    }
+
+    @Override
+    public Object get(Object key) {
+        return MapUtil.getValue(wrapped, (String)key);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        throw new UnsupportedOperationException("Unimplemented method 'put'");
+    }
+
+    @Override
+    public Object remove(Object key) {
+        throw new UnsupportedOperationException("Unimplemented method 'remove'");
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends Object> m) {
+        throw new UnsupportedOperationException("Unimplemented method 'putAll'");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Unimplemented method 'clear'");
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return wrapped.keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return wrapped.values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return wrapped.entrySet();
+    }
+
+}

--- a/cms-core/src/test/java/com/condation/cms/core/content/MapAccessTest.java
+++ b/cms-core/src/test/java/com/condation/cms/core/content/MapAccessTest.java
@@ -1,0 +1,74 @@
+package com.condation.cms.core.content;
+
+/*-
+ * #%L
+ * cms-core
+ * %%
+ * Copyright (C) 2023 - 2024 CondationCMS
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class MapAccessTest {
+
+    static MapAccess sut;
+
+    @BeforeAll
+    static void setup () {
+        sut = new MapAccess(Map.of(
+            "title", "The title",
+            "seo", Map.of(
+                "title", "Seo title"
+            )
+        ));
+    }
+    
+    @Test
+    void test_containsKey_true () {
+        Assertions.assertThat(sut.containsKey("title")).isTrue();
+        Assertions.assertThat(sut.containsKey("seo.title")).isTrue();
+    }
+
+    @Test
+    void test_containsKey_false() {
+        Assertions.assertThat(sut.containsKey("desc")).isFalse();
+        Assertions.assertThat(sut.containsKey("seo.desc")).isFalse();
+    }
+
+    @Test
+    void test_get_with_value() {
+        Assertions.assertThat(sut.get("title")).isEqualTo("The title");
+        Assertions.assertThat(sut.get("seo.title")).isEqualTo("Seo title");
+    }
+
+    @Test
+    void test_get_without_value() {
+        Assertions.assertThat(sut.get("desc")).isNull();
+        Assertions.assertThat(sut.get("seo.desc")).isNull();
+    }
+
+    @Test
+    void test_getOrDefault() {
+        Assertions.assertThat(sut.getOrDefault("desc", "default desc")).isEqualTo("default desc");
+        Assertions.assertThat(sut.getOrDefault("seo.desc", "default seo desc")).isEqualTo("default seo desc");
+    }
+}

--- a/test-server/hosts/features/config/media.toml
+++ b/test-server/hosts/features/config/media.toml
@@ -1,0 +1,21 @@
+[[formats]]
+name = "small"
+width = 256
+height = 256
+format = "webp"
+compression = true
+
+[[formats]]
+name = "big"
+width = 512
+height = 512
+format = "webp"
+compression = true
+
+[[formats]]
+name = "test2"
+width = 72
+height = 72
+format = "webp"
+compression = true
+

--- a/test-server/hosts/features/content/index.md
+++ b/test-server/hosts/features/content/index.md
@@ -3,6 +3,8 @@ title: Startseite
 template: start.html
 search:
     index: false
+seo:
+    description: "Test site for most features"
 ---
 
 # Demo Project

--- a/test-server/themes/parent/templates/libs/fragments.html
+++ b/test-server/themes/parent/templates/libs/fragments.html
@@ -5,7 +5,9 @@
 	<title th:text="${meta.title}"></title>
 	<link rel="canonical" th:href="${site.get('baseurl')} + ${requestContext.uri}" />
 	<link rel="shortcut icon" href="/favicon.ico" />
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+	<meta name="description" th:content="${meta.getOrDefault('seo.description', '')}">
 
 	<script th:inline="javascript">
 		/*<![CDATA[*/


### PR DESCRIPTION
This PR introduce a new MapAccess that make the usage of meta data in template code easier by supporting chained keys

for example:
meta['seo.title'] or meta.getOrDefault('seo.title', 'no title')