### PR TITLE
fix(markdown): correctly render nested inline elements

### DIFF
--- a/cms-content/src/main/java/com/condation/cms/content/markdown/InlineElementRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/InlineElementRule.java
@@ -29,5 +29,5 @@ package com.condation.cms.content.markdown;
  */
 public interface InlineElementRule {
 	
-	InlineBlock next (final String md);
+	InlineBlock next (final InlineElementTokenizer tokenizer, final String md);
 }

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/HighlightInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/HighlightInlineRule.java
@@ -24,6 +24,7 @@ package com.condation.cms.content.markdown.rules.inline;
 
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -35,7 +36,7 @@ public class HighlightInlineRule implements InlineElementRule {
 	private static final Pattern PATTERN = Pattern.compile("(={2})(?<content>.*?)(={2})");
 
 	@Override
-	public InlineBlock next(String md) {
+    public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		var matcher = PATTERN.matcher(md);
 		if (matcher.find()) {
 			return new HighlightInlineBlock(matcher.start(), matcher.end(), matcher.group("content"));

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/ImageInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/ImageInlineRule.java
@@ -27,6 +27,7 @@ import com.condation.cms.api.feature.features.SiteMediaServiceFeature;
 import com.condation.cms.api.utils.ImageUtil;
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import com.google.common.base.Strings;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -40,7 +41,7 @@ public class ImageInlineRule implements InlineElementRule {
 	public static final Pattern PATTERN = Pattern.compile("!\\[(?<alt>[^\\]]*)\\]\\((?<url>[^\\s)]+)(?: \"(?<title>[^\"]*)\")?\\)");
 
 	@Override
-	public InlineBlock next(String md) {
+	public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		Matcher matcher = PATTERN.matcher(md);
 		if (matcher.find()) {
 			return new ImageInlineRule.ImageInlineBlock(matcher.start(), matcher.end(), 

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/ImageLinkInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/ImageLinkInlineRule.java
@@ -28,6 +28,7 @@ import com.condation.cms.api.request.RequestContextScope;
 import com.condation.cms.api.utils.HTTPUtil;
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -42,7 +43,7 @@ public class ImageLinkInlineRule implements InlineElementRule {
 	static final Pattern PATTERN = Pattern.compile("\\[(" + IMAGE_PATTERN + ")\\]\\((?<url>.*?)\\)");
 
 	@Override
-	public InlineBlock next(String md) {
+	public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		var matcher = PATTERN.matcher(md);
 
 		if (matcher.find()) {

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/LinkInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/LinkInlineRule.java
@@ -29,6 +29,7 @@ import com.condation.cms.api.request.RequestContextScope;
 import com.condation.cms.api.utils.HTTPUtil;
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -42,7 +43,7 @@ public class LinkInlineRule implements InlineElementRule {
 	static final Pattern PATTERN = Pattern.compile("\\[(?<text>[^\\]]*)\\]\\((?<url>[^\\s)]+)(?: \"(?<title>[^\"]*)\")?\\)");
 	
 	@Override
-	public InlineBlock next(String md) {
+	public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		var matcher = PATTERN.matcher(md);
 		
 		if (matcher.find()) {

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/NewlineInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/NewlineInlineRule.java
@@ -25,6 +25,7 @@ package com.condation.cms.content.markdown.rules.inline;
 
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -36,7 +37,7 @@ public class NewlineInlineRule implements InlineElementRule {
 	private static final Pattern PATTERN = Pattern.compile(" {2,}+$", Pattern.MULTILINE);
 
 	@Override
-	public InlineBlock next(String md) {
+    public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		var matcher = PATTERN.matcher(md);
 		if (matcher.find()) {
 			return new NewlineInlineBlock(matcher.start(), matcher.end());

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/SubscriptInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/SubscriptInlineRule.java
@@ -25,6 +25,7 @@ package com.condation.cms.content.markdown.rules.inline;
 
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -33,13 +34,12 @@ import java.util.regex.Pattern;
  */
 public class SubscriptInlineRule implements InlineElementRule {
 	
-	private static final Pattern PATTERN = Pattern.compile("(={1})(?<content>.*?)(={1})");
+	private static final Pattern PATTERN = Pattern.compile("(?<selector>=)(?<content>.*?)(?<!\\\\)(\\k<selector>)");
 
-	
-	@Override
-	public InlineBlock next(String md) {
-		var matcher = PATTERN.matcher(md);
-		if (matcher.find()) {
+    @Override
+    public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
+        var matcher = PATTERN.matcher(md);
+        if (matcher.find()) {
 			return new SubscriptInlineBlock(matcher.start(), matcher.end(), matcher.group("content"));
 		}
 		return null;

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/SuperscriptInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/SuperscriptInlineRule.java
@@ -25,6 +25,7 @@ package com.condation.cms.content.markdown.rules.inline;
 
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -33,22 +34,22 @@ import java.util.regex.Pattern;
  */
 public class SuperscriptInlineRule implements InlineElementRule {
 	
-	private static final Pattern PATTERN = Pattern.compile("(\\^{1})(?<content>.*?)(\\^{1})");
+	private static final Pattern PATTERN = Pattern.compile("(?<selector>\\^)(?<content>.*?)(?<!\\\\)(\\k<selector>)");
 
-	
-	@Override
-	public InlineBlock next(String md) {
-		var matcher = PATTERN.matcher(md);
-		if (matcher.find()) {
-			return new SuperscriptBlock(matcher.start(), matcher.end(), matcher.group("content"));
-		}
-		return null;
-	}
-	
-	public static record SuperscriptBlock(int start, int end, String content) implements InlineBlock {
-		@Override
-		public String render() {
-			return "<sup>%s</sup>".formatted(content);
-		}
-	}
+    @Override
+    public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
+        var matcher = PATTERN.matcher(md);
+        if (matcher.find()) {
+            return new SuperscriptBlock(matcher.start(), matcher.end(), matcher.group("content"));
+        }
+        return null;
+    }
+
+    public static record SuperscriptBlock(int start, int end, String content) implements InlineBlock {
+
+        @Override
+        public String render() {
+            return "<sup>%s</sup>".formatted(content);
+        }
+    }
 }

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/TagInlineBlockRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/TagInlineBlockRule.java
@@ -23,6 +23,7 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import com.condation.cms.content.tags.TagMap;
 import com.condation.cms.content.tags.TagParser;
 import java.util.List;
@@ -36,7 +37,7 @@ public class TagInlineBlockRule implements InlineElementRule {
 	private static final TagParser tagParser = new TagParser(null);
 	
 	@Override
-	public InlineBlock next(final String md) {
+	public InlineBlock next(InlineElementTokenizer tokenizer, final String md) {
 
 		List<TagParser.TagInfo> tags = tagParser.findTags(md, new TagMap() {
 			@Override

--- a/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/TextInlineRule.java
+++ b/cms-content/src/main/java/com/condation/cms/content/markdown/rules/inline/TextInlineRule.java
@@ -25,6 +25,7 @@ package com.condation.cms.content.markdown.rules.inline;
 
 import com.condation.cms.content.markdown.InlineBlock;
 import com.condation.cms.content.markdown.InlineElementRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
 import com.google.common.base.Strings;
 
 /**
@@ -34,7 +35,7 @@ import com.google.common.base.Strings;
 public class TextInlineRule implements InlineElementRule {
 	
 	@Override
-	public InlineBlock next(String md) {
+	public InlineBlock next(InlineElementTokenizer tokenizer, String md) {
 		if (Strings.isNullOrEmpty(md)) {
 			return null;
 		}

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/IssuesTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/IssuesTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -52,5 +53,13 @@ public class IssuesTest extends MarkdownTest {
 		Assertions.assertThat(result).isEqualToIgnoringWhitespace(expected);
 	}
 
+	@Test
+	public void issue_with_nested_bold_link() throws IOException {
+		var md = "**[latest release](https://github.com/ConditionCMS/distribution/releases)**";
+		var expected = "<p><strong><a href=\"https://github.com/ConditionCMS/distribution/releases\" id=\"latest-release\">latest release</a></strong></p>";
+
+		var result = SUT.render(md);
+		Assertions.assertThat(result).isEqualToIgnoringWhitespace(expected);
+	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/HighlightInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/HighlightInlineRuleTest.java
@@ -23,6 +23,8 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 
 
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import com.condation.cms.content.markdown.rules.inline.HighlightInlineRule;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,10 +36,11 @@ import org.junit.jupiter.api.Test;
 public class HighlightInlineRuleTest {
 	
 	private HighlightInlineRule sut = new HighlightInlineRule();
+	private InlineElementTokenizer tokenizer = new InlineElementTokenizer(new Options());
 
 	@Test
 	public void correct_pattern() {
-		Assertions.assertThat(sut.next("this is ==important==").render()).isEqualTo("<mark>important</mark>");
+		Assertions.assertThat(sut.next(tokenizer, "this is ==important==").render()).isEqualTo("<mark>important</mark>");
 	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/ImageInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/ImageInlineRuleTest.java
@@ -23,6 +23,8 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 
 
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,17 +36,19 @@ import org.junit.jupiter.api.Test;
 public class ImageInlineRuleTest {
 	
 	ImageInlineRule SUT = new ImageInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void test_image_rule() {
-		var result = SUT.next("![TestBild!](/assets/images/test.jpg)");
+		var result = SUT.next(tokenizer, "![TestBild!](/assets/images/test.jpg)");
 		Assertions.assertThat(result.render())
 				.isEqualToIgnoringWhitespace("<img src=\"/assets/images/test.jpg\" alt=\"TestBild!\" />");
 	}
 	
 	@Test
 	public void test_image_rule_title() {
-		var result = SUT.next("![TestBild!](/assets/images/test.jpg \"Test Bild\")");
+		var result = SUT.next(tokenizer, "![TestBild!](/assets/images/test.jpg \"Test Bild\")");
 		Assertions.assertThat(result.render())
 				.isEqualToIgnoringWhitespace("<img src=\"/assets/images/test.jpg\" alt=\"TestBild!\" title=\"Test Bild\" />");
 	}

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/ImageLinkInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/ImageLinkInlineRuleTest.java
@@ -23,6 +23,8 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 
 
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,17 +36,19 @@ import org.junit.jupiter.api.Test;
 public class ImageLinkInlineRuleTest {
 	
 	ImageLinkInlineRule SUT = new ImageLinkInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void test_image_rule() {
-		var result = SUT.next("[![TestBild](test.jpg \"image title\")](https://google.com)");
+		var result = SUT.next(tokenizer, "[![TestBild](test.jpg \"image title\")](https://google.com)");
 		Assertions.assertThat(result.render())
 				.isEqualToIgnoringWhitespace("<a href=\"https://google.com\" id=\"testbild\"><img src=\"test.jpg\" alt=\"TestBild\" title=\"image title\" /></a>");
 	}
 	
 	@Test
 	public void no_title() {
-		var result = SUT.next("[![TestBild](test.jpg)](https://google.com)");
+		var result = SUT.next(tokenizer, "[![TestBild](test.jpg)](https://google.com)");
 		Assertions.assertThat(result.render())
 				.isEqualToIgnoringWhitespace("<a href=\"https://google.com\" id=\"testbild\"><img src=\"test.jpg\" alt=\"TestBild\"/></a>");
 	}

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/LinkInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/LinkInlineRuleTest.java
@@ -26,6 +26,8 @@ import com.condation.cms.api.feature.features.SitePropertiesFeature;
 import com.condation.cms.api.request.RequestContext;
 import com.condation.cms.api.request.RequestContextScope;
 import com.condation.cms.content.markdown.InlineBlock;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +43,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class LinkInlineRuleTest {
 
 	LinkInlineRule SUT = new LinkInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Mock
 	SiteProperties siteProperties;
@@ -48,7 +52,7 @@ public class LinkInlineRuleTest {
 	@Test
 	public void test_link() {
 
-		var result = SUT.next("[google](https://google.de)");
+		var result = SUT.next(tokenizer, "[google](https://google.de)");
 
 		Assertions.assertThat(result.render())
 				.isEqualTo("<a href=\"https://google.de\" id=\"google\">google</a>");
@@ -57,7 +61,7 @@ public class LinkInlineRuleTest {
 	@Test
 	public void test_link_title() {
 
-		var result = SUT.next("[google](https://google.de \"The Google\")");
+		var result = SUT.next(tokenizer, "[google](https://google.de \"The Google\")");
 
 		Assertions.assertThat(result.render())
 				.isEqualTo("<a href=\"https://google.de\" id=\"google\" title=\"The Google\">google</a>");
@@ -66,7 +70,7 @@ public class LinkInlineRuleTest {
 	@Test
 	public void test_relativ_linking() {
 
-		var result = SUT.next("[relative link](../sibling/test)");
+		var result = SUT.next(tokenizer, "[relative link](../sibling/test)");
 
 		Assertions.assertThat(result.render())
 				.isEqualTo("<a href=\"../sibling/test\" id=\"relative-link\">relative link</a>");
@@ -83,7 +87,7 @@ public class LinkInlineRuleTest {
 		InlineBlock result = null;
 		try {
 			result = ScopedValue.where(RequestContextScope.REQUEST_CONTEXT, requestContext).call(() -> {
-				return SUT.next("[relative link](../sibling/test)");
+				return SUT.next(tokenizer, "[relative link](../sibling/test)");
 			});
 		} catch (Exception ex) {
 			System.getLogger(LinkInlineRuleTest.class.getName()).log(System.Logger.Level.ERROR, (String) null, ex);

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/NewlineInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/NewlineInlineRuleTest.java
@@ -23,6 +23,8 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 
 
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,14 +35,16 @@ import org.junit.jupiter.api.Test;
 public class NewlineInlineRuleTest {
 	
 	NewlineInlineRule sut = new NewlineInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void test_line_with_2_spaces() {
-		Assertions.assertThat(sut.next("  \n").render()).isEqualTo("<br/>");
+		Assertions.assertThat(sut.next(tokenizer, "  \n").render()).isEqualTo("<br/>");
 	}
 	
 	@Test
 	public void test_line_ending_with_2_spaces() {
-		Assertions.assertThat(sut.next("the line  \n").render()).isEqualTo("<br/>");
+		Assertions.assertThat(sut.next(tokenizer, "the line  \n").render()).isEqualTo("<br/>");
 	}
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/StrikethroughInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/StrikethroughInlineRuleTest.java
@@ -24,6 +24,8 @@ package com.condation.cms.content.markdown.rules.inline;
 
 
 import com.condation.cms.content.markdown.rules.inline.StrikethroughInlineRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,10 +36,12 @@ import org.junit.jupiter.api.Test;
 public class StrikethroughInlineRuleTest {
 	
 	private StrikethroughInlineRule sut = new StrikethroughInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void correct_pattern() {
-		Assertions.assertThat(sut.next("this is ~~not~~ correct").render()).isEqualTo("<del>not</del>");
+		Assertions.assertThat(sut.next(tokenizer, "this is ~~not~~ correct").render()).isEqualTo("<del>not</del>");
 	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/StrongInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/StrongInlineRuleTest.java
@@ -23,7 +23,8 @@ package com.condation.cms.content.markdown.rules.inline;
  */
 
 
-import com.condation.cms.content.markdown.rules.inline.StrongInlineRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,17 +35,19 @@ import org.junit.jupiter.api.Test;
 public class StrongInlineRuleTest {
 	
 	private StrongInlineRule sut = new StrongInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void correct_pattern() {
-		Assertions.assertThat(sut.next("__bold__").render()).isEqualTo("<strong>bold</strong>");
-		Assertions.assertThat(sut.next("**bold**").render()).isEqualTo("<strong>bold</strong>");
+		Assertions.assertThat(sut.next(tokenizer, "__bold__").render()).isEqualTo("<strong>bold</strong>");
+		Assertions.assertThat(sut.next(tokenizer, "**bold**").render()).isEqualTo("<strong>bold</strong>");
 	}
 	
 	@Test
 	public void wrong_pattern() {
 		
-		Assertions.assertThat(sut.next("**bold__")).isNull();
+		Assertions.assertThat(sut.next(tokenizer, "**bold__")).isNull();
 	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/SubscriptInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/SubscriptInlineRuleTest.java
@@ -24,6 +24,8 @@ package com.condation.cms.content.markdown.rules.inline;
 
 
 import com.condation.cms.content.markdown.rules.inline.SubscriptInlineRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,10 +36,12 @@ import org.junit.jupiter.api.Test;
 public class SubscriptInlineRuleTest {
 	
 	private SubscriptInlineRule sut = new SubscriptInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void correct_pattern() {
-		Assertions.assertThat(sut.next("H=2=O").render()).isEqualTo("<sub>2</sub>");
+		Assertions.assertThat(sut.next(tokenizer, "H=2=O").render()).isEqualTo("<sub>2</sub>");
 	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/SuperscriptInlineRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/SuperscriptInlineRuleTest.java
@@ -24,6 +24,8 @@ package com.condation.cms.content.markdown.rules.inline;
 
 
 import com.condation.cms.content.markdown.rules.inline.SuperscriptInlineRule;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -34,10 +36,12 @@ import org.junit.jupiter.api.Test;
 public class SuperscriptInlineRuleTest {
 	
 	private SuperscriptInlineRule sut = new SuperscriptInlineRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	public void correct_pattern() {
-		Assertions.assertThat(sut.next("x^2^").render()).isEqualTo("<sup>2</sup>");
+		Assertions.assertThat(sut.next(tokenizer, "x^2^").render()).isEqualTo("<sup>2</sup>");
 	}
 	
 }

--- a/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/TagInlineBlockRuleTest.java
+++ b/cms-content/src/test/java/com/condation/cms/content/markdown/rules/inline/TagInlineBlockRuleTest.java
@@ -25,6 +25,8 @@ package com.condation.cms.content.markdown.rules.inline;
 
 
 import com.condation.cms.content.markdown.InlineBlock;
+import com.condation.cms.content.markdown.InlineElementTokenizer;
+import com.condation.cms.content.markdown.Options;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -37,13 +39,15 @@ import org.junit.jupiter.api.Test;
 public class TagInlineBlockRuleTest {
 	
 	private TagInlineBlockRule sut = new TagInlineBlockRule();
+	Options options = new Options();
+	InlineElementTokenizer tokenizer = new InlineElementTokenizer(options);
 
 	@Test
 	void long_form() {
 
 		String md = "[[link url=\"https://google.de/\"]]Google[[/link]]";
 
-		InlineBlock next = sut.next(md);
+		InlineBlock next = sut.next(tokenizer, md);
 
 		Assertions.assertThat(next)
 				.isNotNull()
@@ -65,7 +69,7 @@ public class TagInlineBlockRuleTest {
 
 		String md = "[[link url=\"https://google.de/\" /]]";
 
-		InlineBlock next = sut.next(md);
+		InlineBlock next = sut.next(tokenizer, md);
 
 		Assertions.assertThat(next)
 				.isNotNull()


### PR DESCRIPTION
The previous implementation of the Markdown renderer processed inline elements sequentially without recursion. This caused issues with nested elements, such as a link inside a bold tag, where the inner element was treated as plain text.

This commit refactors the inline parsing mechanism to be recursive:
- The `InlineElementRule` interface is updated to provide the `InlineElementTokenizer` to each rule.
- Container rules (Strong, Italic, Strikethrough) now re-invoke the tokenizer on their content, allowing for nested elements to be parsed correctly.
- A test case has been added to `IssuesTest.java` to verify the fix for `**[link](url)**` and prevent regressions.
- All inline element rules and their corresponding tests have been updated to reflect the new architecture.